### PR TITLE
fix: add node version to client

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,3 @@
+{
+  "nodeVersion": "24.x"
+}


### PR DESCRIPTION
Add node version 24.x to client for vercel deployment to run vite.